### PR TITLE
Fixes from windows

### DIFF
--- a/whiterabbit/src/main/java/org/ohdsi/whiterabbit/scan/SourceDataScan.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiterabbit/scan/SourceDataScan.java
@@ -296,7 +296,7 @@ public class SourceDataScan implements ScanParameters {
 		try (FileOutputStream out = new FileOutputStream(new File(filename))) {
 			workbook.write(out);
 			out.close();
-			StringUtilities.outputWithTime("Scan report generated: " + filename);
+			StringUtilities.outputWithTime("Scan report generated: " + Paths.get(filename).toAbsolutePath().toString());
 		} catch (IOException ex) {
 			throw new RuntimeException(ex.getMessage());
 		}

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/ScanTestUtils.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/ScanTestUtils.java
@@ -76,6 +76,7 @@ public class ScanTestUtils {
             }
 
         }, timeout(10000));
+        System.out.println("console: >" + console.getText() + "<");
         assertTrue(console.getText().contains(expectedPath.toString()));
 
         return scanResultsSheetMatchesReference(expectedPath, referencePath, dbType);

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/ScanTestUtils.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/ScanTestUtils.java
@@ -76,7 +76,6 @@ public class ScanTestUtils {
             }
 
         }, timeout(10000));
-        System.out.println("console: >" + console.getText() + "<");
         assertTrue(console.getText().contains(expectedPath.toString()));
 
         return scanResultsSheetMatchesReference(expectedPath, referencePath, dbType);

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanMySQLIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanMySQLIT.java
@@ -88,7 +88,6 @@ class SourceDataScanMySQLIT {
         DbSettings dbSettings = getTestDbSettings();
 
         sourceDataScan.process(dbSettings, outFile.toString());
-        Files.copy(outFile, Paths.get("/var/tmp/ScanReport.xlsx"), StandardCopyOption.REPLACE_EXISTING);
         assertTrue(ScanTestUtils.scanResultsSheetMatchesReference(outFile, Paths.get(referenceScanReport.toURI()), DbType.MYSQL));
     }
 

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanOracleIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanOracleIT.java
@@ -140,7 +140,7 @@ class SourceDataScanOracleIT {
         dbSettings.dbType = DbType.ORACLE;
         dbSettings.sourceType = DbSettings.SourceType.DATABASE;
         //dbSettings.server = oracleContainer.getJdbcUrl();
-        dbSettings.server = String.format("%s:%s/%s", "localhost", oracleContainer.getOraclePort(), "XE");
+        dbSettings.server = String.format("%s:%s/%s", oracleContainer.getHost(), oracleContainer.getOraclePort(), "XE");
         if (dbSettings.server.toLowerCase().contains("thin")) {
             dbSettings.server = dbSettings.server.replace("/test", ":test").replace("@", "");
         }

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanSnowflakeIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanSnowflakeIT.java
@@ -82,13 +82,13 @@ public class SourceDataScanSnowflakeIT {
         URL referenceScanReport = SourceDataScanSnowflakeIT.class.getClassLoader().getResource("scan_data/ScanReport-reference-v0.10.7-sql.xlsx");
         assert iniTemplate != null;
         String content = new String(Files.readAllBytes(Paths.get(iniTemplate.toURI())), charset);
-        content = content.replaceAll("%WORKING_FOLDER%", tempDir.toString())
-                .replaceAll("%SNOWFLAKE_ACCOUNT%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_ACCOUNT"))
-                .replaceAll("%SNOWFLAKE_USER%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_USER"))
-                .replaceAll("%SNOWFLAKE_PASSWORD%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_PASSWORD"))
-                .replaceAll("%SNOWFLAKE_WAREHOUSE%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_WAREHOUSE"))
-                .replaceAll("%SNOWFLAKE_DATABASE%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_DATABASE"))
-                .replaceAll("%SNOWFLAKE_SCHEMA%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_SCHEMA"));
+        content = content.replace("%WORKING_FOLDER%", tempDir.toString())
+                .replace("%SNOWFLAKE_ACCOUNT%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_ACCOUNT"))
+                .replace("%SNOWFLAKE_USER%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_USER"))
+                .replace("%SNOWFLAKE_PASSWORD%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_PASSWORD"))
+                .replace("%SNOWFLAKE_WAREHOUSE%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_WAREHOUSE"))
+                .replace("%SNOWFLAKE_DATABASE%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_DATABASE"))
+                .replace("%SNOWFLAKE_SCHEMA%", SnowflakeTestUtils.getPropertyOrFail("SNOWFLAKE_WR_TEST_SCHEMA"));
         Files.write(iniFile, content.getBytes(charset));
         WhiteRabbitMain wrMain = new WhiteRabbitMain(true, new String[]{"-ini", iniFile.toAbsolutePath().toString()});
         assert referenceScanReport != null;

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/TestSourceDataScanCsvIniFile.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/TestSourceDataScanCsvIniFile.java
@@ -50,7 +50,7 @@ class TestSourceDataScanCsvIniFile {
         Path costCsv = Paths.get(TestSourceDataScanCsvIniFile.class.getClassLoader().getResource("scan_data/cost-header.csv").toURI());
         assertNotNull(iniTemplate);
         String content = new String(Files.readAllBytes(Paths.get(iniTemplate.toURI())), charset);
-        content = content.replaceAll("%WORKING_FOLDER%", tempDir.toString());
+        content = content.replace("%WORKING_FOLDER%", tempDir.toString());
         Files.write(iniFile, content.getBytes(charset));
         Files.copy(personCsv, tempDir.resolve("person.csv"));
         Files.copy(costCsv, tempDir.resolve("cost.csv"));

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/TestSourceDataScanSasIniFile.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/TestSourceDataScanSasIniFile.java
@@ -48,7 +48,7 @@ class TestSourceDataScanSasIniFile {
         URL referenceScanReport = TestSourceDataScanSasIniFile.class.getClassLoader().getResource("scan_data/ScanReport-reference-v0.10.7-sas.xlsx");
         assertNotNull(iniTemplate);
         String content = new String(Files.readAllBytes(Paths.get(iniTemplate.toURI())), charset);
-        content = content.replaceAll("%WORKING_FOLDER%", tempDir.toString());
+        content = content.replace("%WORKING_FOLDER%", tempDir.toString());
         FileUtils.copyDirectory(
                 new File(Objects.requireNonNull(TestSourceDataScanSasIniFile.class.getClassLoader().getResource("examples/wr_input_sas")).toURI()),
                 tempDir.toFile());

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/VerifyDistributionIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/VerifyDistributionIT.java
@@ -220,8 +220,5 @@ public class VerifyDistributionIT {
                 .withCopyToContainer(
                         MountableFile.forHostPath("../dist/"),
                         APPDIR_IN_CONTAINER);
-//                .withCopyToContainer(
-//                        MountableFile.forHostPath(tempDir.toString()),
-//                        WORKDIR_IN_CONTAINER);
     }
 }

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/VerifyDistributionIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/VerifyDistributionIT.java
@@ -149,13 +149,13 @@ public class VerifyDistributionIT {
                 URL referenceScanReport = SourceDataScanSnowflakeIT.class.getClassLoader().getResource("scan_data/ScanReport-reference-v0.10.7-sql.xlsx");
                 assert iniTemplate != null;
                 String content = new String(Files.readAllBytes(Paths.get(iniTemplate.toURI())), charset);
-                content = content.replaceAll("%WORKING_FOLDER%", WORKDIR_IN_CONTAINER)
-                        .replaceAll("%SNOWFLAKE_ACCOUNT%", reader.getOrFail("SNOWFLAKE_WR_TEST_ACCOUNT"))
-                        .replaceAll("%SNOWFLAKE_USER%", reader.getOrFail("SNOWFLAKE_WR_TEST_USER"))
-                        .replaceAll("%SNOWFLAKE_PASSWORD%", reader.getOrFail("SNOWFLAKE_WR_TEST_PASSWORD"))
-                        .replaceAll("%SNOWFLAKE_WAREHOUSE%", reader.getOrFail("SNOWFLAKE_WR_TEST_WAREHOUSE"))
-                        .replaceAll("%SNOWFLAKE_DATABASE%", reader.getOrFail("SNOWFLAKE_WR_TEST_DATABASE"))
-                        .replaceAll("%SNOWFLAKE_SCHEMA%", reader.getOrFail("SNOWFLAKE_WR_TEST_SCHEMA"));
+                content = content.replace("%WORKING_FOLDER%", WORKDIR_IN_CONTAINER)
+                        .replace("%SNOWFLAKE_ACCOUNT%", reader.getOrFail("SNOWFLAKE_WR_TEST_ACCOUNT"))
+                        .replace("%SNOWFLAKE_USER%", reader.getOrFail("SNOWFLAKE_WR_TEST_USER"))
+                        .replace("%SNOWFLAKE_PASSWORD%", reader.getOrFail("SNOWFLAKE_WR_TEST_PASSWORD"))
+                        .replace("%SNOWFLAKE_WAREHOUSE%", reader.getOrFail("SNOWFLAKE_WR_TEST_WAREHOUSE"))
+                        .replace("%SNOWFLAKE_DATABASE%", reader.getOrFail("SNOWFLAKE_WR_TEST_DATABASE"))
+                        .replace("%SNOWFLAKE_SCHEMA%", reader.getOrFail("SNOWFLAKE_WR_TEST_SCHEMA"));
                 Files.write(iniFile, content.getBytes(charset));
                 // verify that the distribution of whiterabbit has been generated and is available inside the container
                 ExecResult execResult = javaContainer.execInContainer("sh", "-c", String.format("ls %s", APPDIR_IN_CONTAINER));

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/VerifyDistributionIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/VerifyDistributionIT.java
@@ -17,27 +17,15 @@
  ******************************************************************************/
 package org.ohdsi.whiterabbit.scan;
 
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.runners.Parameterized;
 import org.ohdsi.databases.DBConnector;
 import org.ohdsi.databases.SnowflakeTestUtils;
 import org.ohdsi.databases.configuration.DbType;
-import org.ohdsi.utilities.files.IniFile;
-import org.ohdsi.whiterabbit.WhiteRabbitMain;
-import org.rnorth.ducttape.unreliables.Unreliables;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Container.ExecResult;
-import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
-import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -47,10 +35,6 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.ohdsi.whiterabbit.scan.SourceDataScanSnowflakeIT.*;


### PR DESCRIPTION
Some fixes that were exposed when testing the build on Windows, with a remote Docker host for TestContainers

- some paths were mangled by String.replaceAll()
- no bind mounts for TestContainers, will not work when Docker host is remote
- docker host should not be localhost
- code cleanup