### PR TITLE
Use The Hyve fork of the caciocavello project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 White Rabbit and Rabbit in a Hat are structured as a Maven package. Contributions are welcome.
 
-While the software in the project can be executed with Java 8 (1.8), for development Java 17 is needed.
+While the software in the project can be executed with Java 8 (1.8), for development Java 17 (or higher, currently tested wth 21) is needed.
 This has to do with test and verification dependencies that are not available in a version compatible with Java 8 .
 
 Please note that when using an IDE for development, source and target release must still be Java 8 (1.8) . This is enforced

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Requires Java 1.8 or higher for running, and read access to the database to be s
 
 Dependencies
 ============
-For the distributable packages, the only requirement is Java 8. For building the package, Java 17 and Maven are needed.
+For the distributable packages, the only requirement is Java 8. For building the package, Java 17+ and Maven are needed.
 
 Getting Started
 ===============

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
             <layout>default</layout>
             <url>file:///${project.basedir}/../lib</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -227,10 +231,10 @@
             </plugin>
             <plugin>
                 <!--
-                  While the source and target Java version are still 1.8, Java 17 is required to be able to use
+                  While the source and target Java version are still 1.8, Java 17+ is required to be able to use
                   recent versions of test and verification tools. This plugin enforces the required Java version,
                   and gives a cleaner error message than failing on a dependency that is not compatible with an
-                  older version of Java
+                  older version of Java.
                   -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -244,7 +248,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>17</version>
+                                    <version>[17,22)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -304,6 +308,9 @@
                         <!-- apparently there is no license information available for sqljdbc4, even though
                         it is published on Maven repos -->
                         <exclude>com.microsoft.sqlserver:sqljdbc4</exclude>
+
+                        <!-- temporary exclusion for the patched caciocavallo dependency -->
+                        <exclude>com.github.thehyve:caciocavallo</exclude>
 
                         <!-- PLEASE NOTE: teradata and googlebigquery are provided within the project, they
                              cannot be found on a maven repo; no license info available; they should ideally

--- a/whiterabbit/pom.xml
+++ b/whiterabbit/pom.xml
@@ -267,11 +267,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.apache.httpcomponents</groupId>-->
-<!--            <artifactId>httpclient</artifactId>-->
-<!--            <version>4.5.14</version>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>one.util</groupId>
             <artifactId>streamex</artifactId>
@@ -284,10 +279,19 @@
             <version>5.2.5</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
+        <!-- cacio-tta cannot be used with JDK 18+. Until that is solved in the parent project, use a fixed
+             fork hosted at The Hyve -->
+        <!-- dependency>
             <groupId>com.github.caciocavallosilano</groupId>
             <artifactId>cacio-tta</artifactId>
-            <version>1.17.3</version>
+            <version>1.17.4-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency -->
+        <!-- fixed fork, enabled through the jitpack repository -->
+        <dependency>
+            <groupId>com.github.thehyve</groupId>
+            <artifactId>caciocavallo</artifactId>
+            <version>1.17.4</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-swing-junit -->

--- a/whiterabbit/pom.xml
+++ b/whiterabbit/pom.xml
@@ -48,6 +48,7 @@
                     </systemPropertyVariables>
                     <argLine>
                         -Doracle.jdbc.timezoneAsRegion=false
+                        -XX:+EnableDynamicAgentLoading
                         <!-- Line(s) below are needed to keep TestSourceDataScan.updateEnv() working in java 17+
                              This is considered an acceptable hack since it only affects test code -->
                         --add-exports=java.base/java.util=ALL-UNNAMED
@@ -80,6 +81,7 @@
                     <systemPropertyVariables>
                         <propertyName>propertyValue</propertyName>
                         <projectBuildDirectory>${project.build.directory}</projectBuildDirectory>
+                        <java.awt.headless>false</java.awt.headless>
                     </systemPropertyVariables>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
@@ -88,6 +90,7 @@
                     </includes>
                     <skipTests>${skipIntegrationTests}</skipTests>
                     <argLine>
+                        -XX:+EnableDynamicAgentLoading
                     <!-- experimental workaround for Snowflake JDBC issue,
                          see https://community.snowflake.com/s/article/JDBC-Driver-Compatibility-Issue-With-JDK-16-and-Later -->
                     --add-opens java.base/java.nio=ALL-UNNAMED
@@ -291,7 +294,7 @@
         <dependency>
             <groupId>com.github.thehyve</groupId>
             <artifactId>caciocavallo</artifactId>
-            <version>1.17.4</version>
+            <version>1.17.7</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-swing-junit -->


### PR DESCRIPTION
Use The Hyve fork of the caciocavello project (Swing virtual graphics environment for testing) until the parent project has been fixed for JDK 18+

I created that fork so that I could patch it for a bytecode manipulation trick that no longer works in JDK 18+.

Jitpack is used to create a jar "on the fly" since this is expected to be a temporary solution.