### PR TITLE
Turn on mvn verify in github

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 # Continuous integration, including test and integration test
 name: CI
 
+env:
+  SKIP_ORACLE_TESTS: true
+
 # Run in master and dev branches and in all pull requests to those branches
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,4 @@ jobs:
 
       # Gradle check
       - name: Check
-        run: mvn test
+        run: mvn verify

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanOracleIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanOracleIT.java
@@ -17,8 +17,10 @@
  ******************************************************************************/
 package org.ohdsi.whiterabbit.scan;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.io.TempDir;
 import org.ohdsi.databases.configuration.DbSettings;
 import org.ohdsi.databases.configuration.DbType;
@@ -35,11 +37,16 @@ import java.nio.file.Paths;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class SourceDataScanOracleIT {
 
     private final static String USER_NAME = "test_user";
     private final static String SCHEMA_NAME = USER_NAME;
+
+    // The Oracle test containersomehwat  is slow to start, and these tests can be configured to be skipped by
+    // setting the environment variable SKIP_ORACLE_TESTS to "true" (e.g. in a Github workflow)
+    private final static String SKIP_ORACLE_TESTS = "SKIP_ORACLE_TESTS";
 
     /*
      * Since the database is only read, setting it up once suffices.
@@ -51,22 +58,29 @@ class SourceDataScanOracleIT {
      * for this data is know and could simply be copied instead of composed.
      * Also, for the technical correctness of WhiteRabbit (does it open the database, get the table
      * names and scan those tables), the actual nature of the source data does not matter.
+     *
      */
     @Container
-    public static OracleContainer oracleContainer = new OracleContainer("gvenzl/oracle-xe:11.2.0.2-slim-faststart")
-            .withReuse(true)
-            .usingSid()
-            .withUsername(USER_NAME)
-            .withPassword("test_password")
-            .withDatabaseName("testDB")
-            .withInitScript("scan_data/create_data_oracle.sql");
+    public static OracleContainer oracleContainer;
 
     @BeforeAll
     public static void startContainer() {
+        String skipOracleTests = System.getenv(SKIP_ORACLE_TESTS);
+        assumeTrue(!(StringUtils.isNotEmpty(skipOracleTests) && skipOracleTests.matches("true")),
+                String.format("Skipping Oracle tests, triggered by environment variable %s", SKIP_ORACLE_TESTS));
+
+        oracleContainer = new OracleContainer("gvenzl/oracle-xe:11.2.0.2-slim-faststart")
+                .withReuse(true)
+                .usingSid()
+                .withUsername(USER_NAME)
+                .withPassword("test_password")
+                .withDatabaseName("testDB")
+                .withInitScript("scan_data/create_data_oracle.sql");
         oracleContainer.start();
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = SKIP_ORACLE_TESTS, matches = "true")
     public void connectToDatabase() {
         // this is also implicitly tested by testSourceDataScan(), but having it fail separately helps identify problems quicker
         DbSettings dbSettings = getTestDbSettings();
@@ -76,6 +90,7 @@ class SourceDataScanOracleIT {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = SKIP_ORACLE_TESTS, matches = "true")
     public void testGetTableNames() {
         // this is also implicitly tested by testSourceDataScan(), but having it fail separately helps identify problems quicker
         DbSettings dbSettings = getTestDbSettings();
@@ -83,6 +98,7 @@ class SourceDataScanOracleIT {
         assertEquals(2, tableNames.size());
     }
     @Test
+    @DisabledIfEnvironmentVariable(named = SKIP_ORACLE_TESTS, matches = "true")
     void testSourceDataScan(@TempDir Path tempDir) throws IOException, URISyntaxException {
         loadData();
         Path outFile = tempDir.resolve("scanresult.xslx");

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanOracleIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanOracleIT.java
@@ -44,7 +44,7 @@ class SourceDataScanOracleIT {
     private final static String USER_NAME = "test_user";
     private final static String SCHEMA_NAME = USER_NAME;
 
-    // The Oracle test containersomehwat  is slow to start, and these tests can be configured to be skipped by
+    // The Oracle test container is somewhat  is slow to start, and these tests can be configured to be skipped by
     // setting the environment variable SKIP_ORACLE_TESTS to "true" (e.g. in a Github workflow)
     private final static String SKIP_ORACLE_TESTS = "SKIP_ORACLE_TESTS";
 

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanSnowflakeGuiIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanSnowflakeGuiIT.java
@@ -71,6 +71,7 @@ class SourceDataScanSnowflakeGuiIT {
 
     @BeforeEach
     public void onSetUp() {
+        Assumptions.assumeTrue(new SnowflakeTestUtils.SnowflakeSystemPropertiesFileChecker(), "Snowflake system properties file not available");
         try {
             testContainer = createPythonContainer();
             prepareTestData(testContainer);

--- a/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanSnowflakeIT.java
+++ b/whiterabbit/src/test/java/org/ohdsi/whiterabbit/scan/SourceDataScanSnowflakeIT.java
@@ -56,6 +56,7 @@ public class SourceDataScanSnowflakeIT {
 
     @BeforeEach
     public void setUp() {
+        Assumptions.assumeTrue(new SnowflakeTestUtils.SnowflakeSystemPropertiesFileChecker(), "Snowflake system properties file not available");
         try {
             testContainer = createPythonContainer();
             prepareTestData(testContainer);


### PR DESCRIPTION
Enables the integration tests to run on Github.
Oracle had to be excluded because the "slim" and "faststart" image used in TestContainers does not start fast enough :man_shrugging: .
