### PR TITLE
Issue #324 - RiaH export highlight required and unmapped fields

### DIFF
--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLWordDocumentGenerator.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLWordDocumentGenerator.java
@@ -149,7 +149,15 @@ public class ETLWordDocumentGenerator {
 				int rowNr = 1;
 				for (MappableItem targetField : fieldtoFieldMapping.getTargetItems()) {
 					XWPFTableRow row = table.getRow(rowNr++);
-					row.getCell(0).setText(targetField.getName());
+
+					// Check if the field is non-nullable and prepend an asterisk if true
+					String fieldName = targetField.getName();
+					for (Field field : targetTable.getFields()) {
+						if (field.getName().equals(fieldName) && !field.isNullable()) {
+							fieldName = "*" + fieldName;
+							break;
+						}
+					}
 					
 					StringBuilder source = new StringBuilder();
 					StringBuilder logic = new StringBuilder();
@@ -176,6 +184,15 @@ public class ETLWordDocumentGenerator {
 								comment.append("\n");
 							comment.append(field.getComment().trim());
 						}
+					}
+
+					// Grey out the font if source field, logic, and comment are all empty
+					if (source.toString().trim().isEmpty() && logic.toString().trim().isEmpty() && comment.toString().trim().isEmpty()) {
+						XWPFRun runGrey = row.getCell(0).getParagraphs().get(0).createRun();
+						runGrey.setColor("999999");
+						runGrey.setText(fieldName);
+					} else {
+						row.getCell(0).setText(fieldName);
 					}
 					
 					createCellParagraph(row.getCell(1), source.toString());


### PR DESCRIPTION
Only changes have been made to the export to Word.

- Checks to see if target field is nullable. If it is, prepend an asterisk to the field
- Checks to see if Source Field, Logic, and Comment are empty. If this is the case, the Destination Field is grayed out.
- Fields may have an asterisk AND be grayed out with this logic.