### PR TITLE
Issue 313

### DIFF
--- a/rabbit-core/src/main/java/org/ohdsi/utilities/StringUtilities.java
+++ b/rabbit-core/src/main/java/org/ohdsi/utilities/StringUtilities.java
@@ -17,7 +17,6 @@
  ******************************************************************************/
 package org.ohdsi.utilities;
 
-import org.ohdsi.utilities.collections.CountingSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +24,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.zip.DataFormatException;
@@ -862,7 +860,6 @@ public class StringUtilities {
 
 
 	public static boolean isDate(String string) {
-
 		for (String dateFormat : dateFormats){
 			DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(dateFormat);
 			try {
@@ -871,7 +868,6 @@ public class StringUtilities {
 			} catch (Exception ignored){}
 		}
 		return false;
-
 	}
 
 	public static int numericOptionToInt(String option) {

--- a/rabbit-core/src/main/java/org/ohdsi/utilities/StringUtilities.java
+++ b/rabbit-core/src/main/java/org/ohdsi/utilities/StringUtilities.java
@@ -25,14 +25,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.Iterator;
-import java.util.List;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.zip.DataFormatException;
 
 public class StringUtilities {
@@ -49,7 +44,34 @@ public class StringUtilities {
 	public static long		MISSING_DATE	= -999999;
 	
 	private static Calendar	calendar		= new GregorianCalendar();
-	
+
+	private static List<String> dateFormats = generateDateFormats();
+
+	private static List<String> generateDateFormats(){
+		List<String> formats = new ArrayList<>();
+		String[] yearFormats = new String[]{"yy", "yyyy"};
+		String[] monthFormats = new String[]{"M", "MM"};
+		String[] dayFormats = new String[]{"d", "dd"};
+
+		String[] separatorFormats = new String[]{"/", ".", "-", " "};
+
+		for (String sep : separatorFormats){
+			for (String year : yearFormats){
+				for (String month : monthFormats){
+					for (String day : dayFormats){
+						// YMD
+						formats.add(year + sep + month + sep + day);
+						//DMY
+						formats.add(day + sep + month + sep + year);
+						//MDY
+						formats.add(month + sep + day + sep + year);
+					}
+				}
+			}
+		}
+		return formats;
+	}
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static String joinSorted(Collection<? extends Comparable> s, String delimiter) {
 		List list = new ArrayList(s);
@@ -837,41 +859,19 @@ public class StringUtilities {
 			return text;
 		}
 	}
-	
+
+
 	public static boolean isDate(String string) {
-		if (string.length() == 10) {
-			if ((string.charAt(4) == '-' || string.charAt(4) == '/') || (string.charAt(4) == string.charAt(7)))
-				try {
-					int year = Integer.parseInt(string.substring(0, 4));
-					if (year < 1700 || year > 2200)
-						return false;
-					int month = Integer.parseInt(string.substring(5, 7));
-					if (month < 1 || month > 12)
-						return false;
-					int day = Integer.parseInt(string.substring(8, 10));
-					if (day < 1 || day > 31)
-						return false;
-					return true;
-				} catch (Exception e) {
-					return false;
-				}
-		} else if (string.length() == 8) {
-			if ((string.charAt(2) == '-' || string.charAt(5) == '/') || (string.charAt(2) == string.charAt(5)))
-				try {
-					Integer.parseInt(string.substring(6, 8));
-					int month = Integer.parseInt(string.substring(0, 2));
-					if (month < 1 || month > 12)
-						return false;
-					int day = Integer.parseInt(string.substring(3, 5));
-					if (day < 1 || day > 31)
-						return false;
-					return true;
-				} catch (Exception e) {
-					return false;
-				}
-			
+
+		for (String dateFormat : dateFormats){
+			DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(dateFormat);
+			try {
+				dateFormatter.parse(string);
+				return true;
+			} catch (Exception ignored){}
 		}
 		return false;
+
 	}
 
 	public static int numericOptionToInt(String option) {

--- a/rabbit-core/src/test/java/org/ohdsi/utilities/StringUtilitiesTest.java
+++ b/rabbit-core/src/test/java/org/ohdsi/utilities/StringUtilitiesTest.java
@@ -1,0 +1,40 @@
+package org.ohdsi.utilities;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringUtilitiesTest {
+
+    @Test
+    void isDate() {
+        // previously supported date formats: yyyy.mm.dd or mm.dd.yy ("." may be any separator)
+        assertTrue(StringUtilities.isDate("31.01.23"));
+        assertTrue(StringUtilities.isDate("31.12.32"));
+        assertTrue(StringUtilities.isDate("12.31.32"));
+        assertTrue(StringUtilities.isDate("2023.01.31"));
+        assertTrue(StringUtilities.isDate("2032.12.31"));
+        assertFalse(StringUtilities.isDate("2032.12.32"));
+
+        // more generally supported date formats after implementing issue #313 (copilot generated)
+        assertTrue(StringUtilities.isDate("2023-01-01"));
+        assertTrue(StringUtilities.isDate("01/01/2023"));
+        assertTrue(StringUtilities.isDate("01-01-2023"));
+        assertTrue(StringUtilities.isDate("01.01.2023"));
+        assertTrue(StringUtilities.isDate("2023/01/01"));
+        assertTrue(StringUtilities.isDate("2023.01.01"));
+        assertTrue(StringUtilities.isDate("2023 01 01"));
+        assertTrue(StringUtilities.isDate("01 01 2023"));
+        assertFalse(StringUtilities.isDate("2023-13-01"));
+        assertFalse(StringUtilities.isDate("2023-01-32"));
+        assertFalse(StringUtilities.isDate("2023/01/32"));
+        assertFalse(StringUtilities.isDate("not a date"));
+
+        assertTrue(StringUtilities.isDate("2023-12-31"));
+        assertTrue(StringUtilities.isDate("12-31-2023"));
+        assertTrue(StringUtilities.isDate("12-13-2023"));
+        assertTrue(StringUtilities.isDate("13-12-2023"));
+        assertFalse(StringUtilities.isDate("13-13-2023"));
+
+    }
+}


### PR DESCRIPTION
added support for reading the following date formats:
order formats: `"YMD", "DMY, "MDY"`
year formats: `"yy", "yyyy"`
month formats: `"M", "MM"` (works with single digit month notations)
day formats: `"d", "dd"` (also works with single digit day notations)
separator formats: `"/", ".", "-", " "`