### PR TITLE
Fix source fields in RiaH mapping view

### DIFF
--- a/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Database.java
+++ b/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Database.java
@@ -56,6 +56,8 @@ public class Database implements Serializable {
 	private static final String	CONCEPT_ID_HINTS_FILE_NAME = "CDMConceptIDHints.csv";
 	public String 				conceptIdHintsVocabularyVersion;
 	private List<Integer>		selectedIndices;
+	private boolean 			hasStemTable = false;
+	private Table 				stemTable;
 
 	public List<Table> getTables() {
 		if(selectedIndices != null){
@@ -63,9 +65,13 @@ public class Database implements Serializable {
             for (Integer selectedIndex : selectedIndices) {
                 maskedTables.add(tables.get(selectedIndex));
             }
+			if (hasStemTable) {
+				maskedTables.add(stemTable);
+			}
 			return maskedTables;
+		} else {
+			return tables;
 		}
-		return tables;
 	}
 
 	public List<Table> getUnmaskedTables() {
@@ -85,6 +91,16 @@ public class Database implements Serializable {
 
 	public void addTable(Table table) {
 		this.tables.add(table);
+	}
+
+	public void addStemTable(Table stemTable) {
+		this.stemTable = stemTable;
+		this.hasStemTable = true;
+	}
+
+	public void removeStemTable() {
+		this.hasStemTable = false;
+		this.stemTable = null;
 	}
 
 	public String getDbName() {

--- a/rabbitinahat/pom.xml
+++ b/rabbitinahat/pom.xml
@@ -172,6 +172,14 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <encoding>ISO-8859-1</encoding>
+                </configuration>
+            </plugin>
         </plugins>
         <testResources>
             <testResource>

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/Arrow.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/Arrow.java
@@ -258,4 +258,8 @@ public class Arrow implements MappingComponent {
 	public boolean isConnected(){
 		return source != null && target != null;
 	}
+
+	public Point getPointInside() {
+		return new Point((x1 + x2) / 2, (y1 + y2) / 2);
+	}
 }

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
@@ -90,7 +90,7 @@ public class ETLMarkupDocumentGenerator {
 	}
 
 	private void addTableLevelSection() {
-		MappingPanel mappingPanel = new MappingPanel(etl.getTableToTableMapping());
+		MappingPanel mappingPanel = new MappingPanel(etl.getTableToTableMapping(), MappingPanel.MappingType.TABLES);
 		mappingPanel.setShowOnlyConnectedItems(true);
 		int height = mappingPanel.getMinimumSize().height;
 		mappingPanel.setSize(800, height);
@@ -130,7 +130,7 @@ public class ETLMarkupDocumentGenerator {
 				}
 
 				// Add image of field to field mapping
-				MappingPanel mappingPanel = new MappingPanel(fieldtoFieldMapping);
+				MappingPanel mappingPanel = new MappingPanel(fieldtoFieldMapping, MappingPanel.MappingType.FIELDS);
 				mappingPanel.setShowOnlyConnectedItems(true);
 				int height = mappingPanel.getMinimumSize().height;
 				mappingPanel.setSize(800, height);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLWordDocumentGenerator.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLWordDocumentGenerator.java
@@ -111,33 +111,34 @@ public class ETLWordDocumentGenerator {
 		run.setFontSize(18);
 		
 		createDocumentParagraph(document, targetTable.getComment());
-		
-		for (ItemToItemMap tableToTableMap : etl.getTableToTableMapping().getSourceToTargetMaps())
-			if (tableToTableMap.getTargetItem() == targetTable && etl.isSelectedTable(tableToTableMap.getSourceItem())) {
+
+		for (ItemToItemMap tableToTableMap : etl.getTableToTableMapping().getSourceToTargetMaps()) {
+			MappableItem item = tableToTableMap.getSourceItem();
+			if (tableToTableMap.getTargetItem() == targetTable && (item.getClass().isInstance(Field.class) || etl.isSelectedTable(tableToTableMap.getSourceItem()))) {
 				Table sourceTable = (Table) tableToTableMap.getSourceItem();
 				Mapping<Field> fieldtoFieldMapping = etl.getFieldToFieldMapping(sourceTable, targetTable);
-				
+
 				paragraph = document.createParagraph();
 				run = paragraph.createRun();
 				run.setText("Reading from " + tableToTableMap.getSourceItem());
 				run.setFontSize(14);
-				
+
 				createDocumentParagraph(document, tableToTableMap.getLogic());
-				
+
 				createDocumentParagraph(document, tableToTableMap.getComment());
-				
+
 				// Add picture of field to field mapping
-				MappingPanel mappingPanel = new MappingPanel(fieldtoFieldMapping);
+				MappingPanel mappingPanel = new MappingPanel(fieldtoFieldMapping, MappingPanel.MappingType.FIELDS);
 				mappingPanel.setShowOnlyConnectedItems(true);
 				int height = mappingPanel.getMinimumSize().height;
 				mappingPanel.setSize(800, height);
-				
+
 				BufferedImage im = new BufferedImage(800, height, BufferedImage.TYPE_INT_ARGB);
 				im.getGraphics().setColor(Color.WHITE);
 				im.getGraphics().fillRect(0, 0, im.getWidth(), im.getHeight());
 				mappingPanel.paint(im.getGraphics());
 				document.addPicture(im, 600, height * 6 / 8);
-				
+
 				// Add table of field to field mapping
 				XWPFTable table = document.createTable(fieldtoFieldMapping.getTargetItems().size() + 1, 4);
 				// table.setWidth(2000);
@@ -158,7 +159,7 @@ public class ETLWordDocumentGenerator {
 							break;
 						}
 					}
-					
+
 					StringBuilder source = new StringBuilder();
 					StringBuilder logic = new StringBuilder();
 					StringBuilder comment = new StringBuilder();
@@ -167,17 +168,17 @@ public class ETLWordDocumentGenerator {
 							if (source.length() != 0)
 								source.append("\n");
 							source.append(fieldToFieldMap.getSourceItem().getName().trim());
-							
+
 							if (logic.length() != 0)
 								logic.append("\n");
 							logic.append(fieldToFieldMap.getLogic().trim());
-							
+
 							if (comment.length() != 0)
 								comment.append("\n");
 							comment.append(fieldToFieldMap.getComment().trim());
 						}
 					}
-					
+
 					for (Field field : targetTable.getFields()) {
 						if (field.getName().equals(targetField.getName())) {
 							if (comment.length() != 0)
@@ -194,13 +195,13 @@ public class ETLWordDocumentGenerator {
 					} else {
 						row.getCell(0).setText(fieldName);
 					}
-					
+
 					createCellParagraph(row.getCell(1), source.toString());
 					createCellParagraph(row.getCell(2), logic.toString());
 					createCellParagraph(row.getCell(3), comment.toString());
 				}
 			}
-		
+		}
 	}
 	
 	private static void setTextAndHeaderShading(XWPFTableCell cell, String text) {
@@ -218,7 +219,7 @@ public class ETLWordDocumentGenerator {
 		XWPFParagraph tmpParagraph = document.createParagraph();
 		XWPFRun tmpRun = tmpParagraph.createRun();
 		
-		MappingPanel mappingPanel = new MappingPanel(etl.getTableToTableMapping());
+		MappingPanel mappingPanel = new MappingPanel(etl.getTableToTableMapping(), MappingPanel.MappingType.TABLES);
 		mappingPanel.setShowOnlyConnectedItems(true);
 		int height = mappingPanel.getMinimumSize().height;
 		mappingPanel.setSize(800, height);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -99,8 +99,31 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	private DetailsListener			detailsListener;
 
 	@SuppressWarnings("serial")
-	public MappingPanel(Mapping<? extends MappableItem> mapping) {
+	private MappingPanel(Mapping<? extends MappableItem> mapping) {
 		super();
+		this.mapping = mapping;
+		this.setFocusable(true);
+		addMouseListener(this);
+		addMouseMotionListener(this);
+
+		// Add keybindings to delete arrows
+		this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0, false), "del pressed");
+		this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0, false), "del pressed");
+		this.getActionMap().put("del pressed", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				if (selectedArrow != null) {
+					removeArrow(selectedArrow);
+				}
+			}
+		});
+
+		renderModel();
+	}
+
+	public MappingPanel(Mapping<? extends MappableItem> mapping, MappingType mappingType) {
+		super();
+		this.mappingType = mappingType;
 		this.mapping = mapping;
 		this.setFocusable(true);
 		addMouseListener(this);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -100,25 +100,6 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 
 	@SuppressWarnings("serial")
 	private MappingPanel(Mapping<? extends MappableItem> mapping) {
-		super();
-		this.mapping = mapping;
-		this.setFocusable(true);
-		addMouseListener(this);
-		addMouseMotionListener(this);
-
-		// Add keybindings to delete arrows
-		this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0, false), "del pressed");
-		this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0, false), "del pressed");
-		this.getActionMap().put("del pressed", new AbstractAction() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				if (selectedArrow != null) {
-					removeArrow(selectedArrow);
-				}
-			}
-		});
-
-		renderModel();
 	}
 
 	public MappingPanel(Mapping<? extends MappableItem> mapping, MappingType mappingType) {

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -930,6 +930,6 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	}
 
 	private boolean isTableAndSelected(MappableItem item) {
-		return mappingType == MappingType.FIELDS || ObjectExchange.etl.isSelectedTable(item);
+		return mappingType == MappingType.FIELDS || item.isStem() || ObjectExchange.etl.isSelectedTable(item);
 	}
 }

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -64,12 +64,16 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	public static final int				BORDER_HEIGHT				= 25;
 	// Extra margin between header and first item when using stem table
 	public static final int				STEM_HEIGHT_MARGIN			= ITEM_HEIGHT / 2;
+	public static enum MappingType {
+		TABLES, FIELDS
+	}
+	private MappingType				mappingType					= MappingType.TABLES;
 
 	private int						sourceX;
 	private int						cdmX;
 	private int						stemX;
 
-	private Mapping<?>				mapping;
+	private Mapping<? extends MappableItem>				mapping;
 	private List<LabeledRectangle>	sourceComponents			= new ArrayList<LabeledRectangle>();
 	private List<LabeledRectangle>	cdmComponents				= new ArrayList<LabeledRectangle>();
 	private List<Arrow>				arrows						= new ArrayList<Arrow>();
@@ -95,7 +99,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	private DetailsListener			detailsListener;
 
 	@SuppressWarnings("serial")
-	public MappingPanel(Mapping<?> mapping) {
+	public MappingPanel(Mapping<? extends MappableItem> mapping) {
 		super();
 		this.mapping = mapping;
 		this.setFocusable(true);
@@ -129,7 +133,17 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		return minimized;
 	}
 
-	public void setMapping(Mapping<?> mapping) {
+	public void setFieldMapping(Mapping<? extends MappableItem> mapping) {
+		mappingType = MappingType.FIELDS;
+		setMapping(mapping);
+	}
+
+	public void setTableMapping(Mapping<? extends MappableItem> mapping) {
+		mappingType = MappingType.TABLES;
+		setMapping(mapping);
+	}
+
+	private void setMapping(Mapping<? extends MappableItem> mapping) {
 		maximize();
 		this.mapping = mapping;
 		renderModel();
@@ -166,7 +180,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		cdmComponents.clear();
 		arrows.clear();
 		for (MappableItem item : mapping.getSourceItems()) {
-			if (ObjectExchange.etl.isSelectedTable(item)) {
+			if (isTableAndSelected(item)) {
 				if (!showOnlyConnectedItems || isConnected(item)) {
 					if (item.isStem())
 						sourceComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
@@ -184,7 +198,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			}
 		}
 		for (ItemToItemMap map : mapping.getSourceToTargetMaps()) {
-			if (ObjectExchange.etl.isSelectedTable(map.getSourceItem())) {
+			if (isTableAndSelected(map.getSourceItem())) {
 				Arrow component = new Arrow(getComponentWithItem(map.getSourceItem(), sourceComponents), getComponentWithItem(map.getTargetItem(), cdmComponents),
 						map);
 				arrows.add(component);
@@ -436,7 +450,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 				if (event.getClickCount() == 2) { // double click
 					zoomArrow = clickedArrow;
 					if (slaveMappingPanel != null) {
-						slaveMappingPanel.setMapping(ObjectExchange.etl.getFieldToFieldMapping((Table) zoomArrow.getSource().getItem(), (Table) zoomArrow
+						slaveMappingPanel.setFieldMapping(ObjectExchange.etl.getFieldToFieldMapping((Table) zoomArrow.getSource().getItem(), (Table) zoomArrow
 								.getTarget().getItem()));
 						new AnimateThread(true).start();
 
@@ -779,7 +793,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 				if (event.getClickCount() == 2 && isSourceComponent && !component.getItem().isStem()) {
 					if (slaveMappingPanel != null) {
 						// Create dummy mapping
-						slaveMappingPanel.setMapping(
+						slaveMappingPanel.setFieldMapping(
 								new Mapping<>(((Table) component.getItem()).getFields(), new ArrayList<>(), new ArrayList<>())
 						);
 						// Zoom arrow has to be set, but will not be shown
@@ -909,5 +923,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 
 	public boolean isBeingFiltered() {
 		return lastSourceFilter != "" || lastTargetFilter != "";
+	}
+
+	private boolean isTableAndSelected(MappableItem item) {
+		return mappingType == MappingType.FIELDS || ObjectExchange.etl.isSelectedTable(item);
 	}
 }

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MaskListDialog.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MaskListDialog.java
@@ -283,7 +283,7 @@ public class MaskListDialog extends JDialog implements ActionListener, ResizeLis
 
     private void updateIndices(){
         ObjectExchange.etl.getSourceDatabase().setSelectedIndices(getSelectedIndices());
-        mappingPanel.setMapping(ObjectExchange.etl.getTableToTableMapping());
+        mappingPanel.setTableMapping(ObjectExchange.etl.getTableToTableMapping());
     }
 
     public List<Integer> getSelectedIndices(){

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -89,6 +89,7 @@ public class RabbitInAHatMain implements ResizeListener {
 
 	public final static String PANEL_TABLE_MAPPING = "Table Mapping";
 	public final static String PANEL_FIELD_MAPPING = "Field Mapping";
+	public final static String PANEL_DETAILS = "Details";
 	public final static String MASK_LIST_DIALOG = "Mask List Dialog";
 
 	public final static String DOCUMENTATION_URL = "http://ohdsi.github.io/WhiteRabbit/RabbitInAHat.html";
@@ -167,6 +168,7 @@ public class RabbitInAHatMain implements ResizeListener {
 		tableFieldSplitPane.setName("splitpane");
 
 		detailsPanel = new DetailsPanel();
+		detailsPanel.setName(PANEL_DETAILS);
 		detailsPanel.setBorder(new TitledBorder("Details"));
 		detailsPanel.setPreferredSize(new Dimension(200, 500));
 		detailsPanel.setMinimumSize(new Dimension(0, 0));
@@ -437,7 +439,7 @@ public class RabbitInAHatMain implements ResizeListener {
 		}
 
 		StemTableFactory.addStemTable(ObjectExchange.etl);
-		tableMappingPanel.setMapping(ObjectExchange.etl.getTableToTableMapping());
+		tableMappingPanel.setTableMapping(ObjectExchange.etl.getTableToTableMapping());
 	}
 
 	private void doRemoveStemTable() {
@@ -454,7 +456,7 @@ public class RabbitInAHatMain implements ResizeListener {
 
 		if (PromptResult==JOptionPane.YES_OPTION) {
 			StemTableFactory.removeStemTable(ObjectExchange.etl);
-			tableMappingPanel.setMapping(ObjectExchange.etl.getTableToTableMapping());
+			tableMappingPanel.setTableMapping(ObjectExchange.etl.getTableToTableMapping());
 		}
 	}
 
@@ -501,7 +503,7 @@ public class RabbitInAHatMain implements ResizeListener {
 				ETL etl = new ETL(ObjectExchange.etl.getSourceDatabase(), Database.generateModelFromCSV(stream, file.getName()));
 
 				etl.copyETLMappings(ObjectExchange.etl);
-				tableMappingPanel.setMapping(etl.getTableToTableMapping());
+				tableMappingPanel.setTableMapping(etl.getTableToTableMapping());
 				ObjectExchange.etl = etl;
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -518,7 +520,7 @@ public class RabbitInAHatMain implements ResizeListener {
 	private void doSetTargetCDM(CDMVersion cdmVersion) throws IOException {
 		ETL etl = new ETL(ObjectExchange.etl.getSourceDatabase(), Database.generateCDMModel(cdmVersion));
 		etl.copyETLMappings(ObjectExchange.etl);
-		tableMappingPanel.setMapping(etl.getTableToTableMapping());
+		tableMappingPanel.setTableMapping(etl.getTableToTableMapping());
 		ObjectExchange.etl = etl;
 	}
 
@@ -588,7 +590,7 @@ public class RabbitInAHatMain implements ResizeListener {
 					: filename.endsWith(".json") ? ETL.FileFormat.Json : ETL.FileFormat.Binary;
 			try {
 				ObjectExchange.etl = ETL.fromFile(filename, fileFormat);
-				tableMappingPanel.setMapping(ObjectExchange.etl.getTableToTableMapping());
+				tableMappingPanel.setTableMapping(ObjectExchange.etl.getTableToTableMapping());
 			} catch (Exception e) {
 				e.printStackTrace();
 				JOptionPane.showMessageDialog(null, "Invalid File Format", "Error", JOptionPane.ERROR_MESSAGE);
@@ -623,7 +625,7 @@ public class RabbitInAHatMain implements ResizeListener {
 				etl.setSourceDatabase(Database.generateModelFromScanReport(filename));
 				etl.setTargetDatabase(ObjectExchange.etl.getTargetDatabase());
 				ObjectExchange.etl = etl;
-				tableMappingPanel.setMapping(etl.getTableToTableMapping());
+				tableMappingPanel.setTableMapping(etl.getTableToTableMapping());
 				ObjectExchange.etl = etl;
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -658,7 +660,7 @@ public class RabbitInAHatMain implements ResizeListener {
 						oldData.addTable(newTable);
 					}
 				}
-				tableMappingPanel.setMapping(ObjectExchange.etl.getTableToTableMapping()); // Needed to render the model
+				tableMappingPanel.setTableMapping(ObjectExchange.etl.getTableToTableMapping()); // Needed to render the model
 			} catch (Exception e) {
 				e.printStackTrace();
 				JOptionPane.showMessageDialog(null, "Invalid File Format", "Error", JOptionPane.ERROR_MESSAGE);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -255,8 +255,8 @@ public class RabbitInAHatMain implements ResizeListener {
 		menuBar.add(editMenu);
 		addMenuItem(editMenu, ACTION_DISCARD_COUNTS, evt -> this.doDiscardCounts());
 		addMenuItem(editMenu, ACTION_FILTER, evt -> this.doOpenFilterDialog(), KeyEvent.VK_F);
-		addMenuItem(editMenu, ACTION_ADD_STEM_TABLE, evt -> this.doAddStemTable());
-		addMenuItem(editMenu, ACTION_REMOVE_STEM_TABLE, evt -> this.doRemoveStemTable());
+		addMenuItem(editMenu, ACTION_ADD_STEM_TABLE, evt -> this.doAddStemTable()).setName(ACTION_ADD_STEM_TABLE);
+		addMenuItem(editMenu, ACTION_REMOVE_STEM_TABLE, evt -> this.doRemoveStemTable()).setName(ACTION_REMOVE_STEM_TABLE);
 		addMenuItem(editMenu, ACTION_HIDE_TABLES, evt -> this.doHideTables()).setName(ACTION_HIDE_TABLES);
 
 		JMenu targetDatabaseMenu = new JMenu("Set Target Database");

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -141,7 +141,7 @@ public class RabbitInAHatMain implements ResizeListener {
 
 		ObjectExchange.etl = etl;
 
-		tableMappingPanel = new MappingPanel(etl.getTableToTableMapping());
+		tableMappingPanel = new MappingPanel(etl.getTableToTableMapping(), MappingPanel.MappingType.TABLES);
 		tableMappingPanel.setName(PANEL_TABLE_MAPPING);
 		tableMappingPanel.addResizeListener(this);
 		scrollPane1 = new JScrollPane(tableMappingPanel);
@@ -152,7 +152,11 @@ public class RabbitInAHatMain implements ResizeListener {
 		scrollPane1.setOpaque(true);
 		scrollPane1.setBackground(Color.WHITE);
 
-		fieldMappingPanel = new MappingPanel(etl.getTableToTableMapping());
+		// the statement below does not make sense (inserts a table mapping in the field mapping panel), but there is no
+		// easy way to initialize the panel in a meaningful way, and it does prevent some things in the UI from being
+		// uninitialized, so leaving it as-is
+		fieldMappingPanel = new MappingPanel(etl.getTableToTableMapping(), MappingPanel.MappingType.TABLES);
+
 		fieldMappingPanel.setName(PANEL_FIELD_MAPPING);
 		tableMappingPanel.setSlaveMappingPanel(fieldMappingPanel);
 		fieldMappingPanel.addResizeListener(this);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/ETL.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/ETL.java
@@ -249,6 +249,9 @@ public class ETL implements Serializable {
 	}
 
 	public boolean isSelectedTable(MappableItem item) {
+		if (item.isStem()) {
+			return true;
+		}
 		List<Integer> indices = sourceDb.getSelectedIndices();
 		for(int i : indices){
 			if(sourceDb.getUnmaskedTables().get(i) == item){

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
@@ -33,7 +33,7 @@ import org.ohdsi.utilities.collections.Pair;
 
 public class StemTableFactory {
 
-	private static final String STEM_TABLE_NAME = "stem_table";
+	public static final String STEM_TABLE_NAME = "stem_table";
 
 	public static void addStemTable(ETL etl) {
 		Database sourceDatabase = etl.getSourceDatabase();
@@ -76,10 +76,10 @@ public class StemTableFactory {
 				field.setStem(true);
 				sourceStemTable.getFields().add(field);
 			}
-			sourceDatabase.getTables().add(sourceStemTable);
+			sourceDatabase.addStemTable(sourceStemTable);
 			Table targetStemTable = new Table(sourceStemTable);
 			targetStemTable.setDb(targetDatabase);
-			targetDatabase.getTables().add(targetStemTable);
+			targetDatabase.addStemTable(targetStemTable);
 
 			Mapping<Table> mapping = etl.getTableToTableMapping();
 			Map<String, Table> nameToTable = new HashMap<>();
@@ -96,11 +96,9 @@ public class StemTableFactory {
 				Field targetField = targetTable.getFieldByName(row.get("TARGET_FIELD"));
 				fieldToFieldMapping.addSourceToTargetMap(sourceField, targetField);
 			}
-
 		} catch (IOException e) {
 			throw new RuntimeException(e.getMessage());
 		}
-
 	}
 
 	public static void removeStemTable(ETL etl) {
@@ -121,25 +119,8 @@ public class StemTableFactory {
 			mapping.removeSourceToTargetMap(tableTablePair.getItem1(), tableTablePair.getItem2());
 		}
 
-		// Remove stem source table
-		Database sourceDatabase = etl.getSourceDatabase();
-		List<Table> newSourceTables = new ArrayList<>();
-		for (Table table : sourceDatabase.getTables()) {
-			if (!table.isStem()) {
-				newSourceTables.add(table);
-			}
-		}
-		sourceDatabase.setTables(newSourceTables);
-
-		// Remove stem target table
-		Database targetDatabase = etl.getTargetDatabase();
-		List<Table> newTargetTables = new ArrayList<>();
-		for (Table table : targetDatabase.getTables()) {
-			if (!table.isStem()) {
-				newTargetTables.add(table);
-			}
-		}
-		targetDatabase.setTables(newTargetTables);
+		etl.getSourceDatabase().removeStemTable();
+		etl.getTargetDatabase().removeStemTable();
 	}
 
 }

--- a/rabbitinahat/src/test/java/org/ohdsi/rabbitInAHat/RabbitInAHatIT.java
+++ b/rabbitinahat/src/test/java/org/ohdsi/rabbitInAHat/RabbitInAHatIT.java
@@ -58,7 +58,7 @@ import static org.ohdsi.rabbitInAHat.RabbitInAHatMain.*;
  */
 @CacioTest
 
-public class TestRabbitInAHatMain {
+public class RabbitInAHatIT {
 
     private static FrameFixture window;
 
@@ -108,7 +108,7 @@ public class TestRabbitInAHatMain {
         window.menuItem(ACTION_OPEN_SCAN_REPORT).click();
         JFileChooserFixture fileChooser = JFileChooserFinder.findFileChooser().using(window.robot());
         assertEquals(TITLE_SELECT_FILE, fileChooser.target().getDialogTitle());
-        URL scanReportUrl = TestRabbitInAHatMain.class.getClassLoader().getResource("examples/test_scanreports/ScanReport_minimal.xlsx");
+        URL scanReportUrl = RabbitInAHatIT.class.getClassLoader().getResource("examples/test_scanreports/ScanReport_minimal.xlsx");
         fileChooser.selectFile(new File(Objects.requireNonNull(scanReportUrl).toURI())).approve();
     }
 

--- a/rabbitinahat/src/test/java/org/ohdsi/rabbitInAHat/RiahTestUtils.java
+++ b/rabbitinahat/src/test/java/org/ohdsi/rabbitInAHat/RiahTestUtils.java
@@ -1,0 +1,42 @@
+package org.ohdsi.rabbitInAHat;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class RiahTestUtils {
+    public static void unzip(Path zipFileName, Path destination) throws IOException {
+
+        if (!Files.exists(zipFileName)){
+            throw new IOException("File not found: " + zipFileName);
+        }
+        try (ZipFile zipFile = new ZipFile(zipFileName.toFile(), ZipFile.OPEN_READ)){
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                Path entryPath = destination.resolve(entry.getName());
+                if (entryPath.normalize().startsWith(destination.normalize())){
+                    if (entry.isDirectory()) {
+                        Files.createDirectories(entryPath);
+                    } else {
+                        Files.createDirectories(entryPath.getParent());
+                        try (InputStream in = zipFile.getInputStream(entry)){
+                            try (OutputStream out = new FileOutputStream(entryPath.toFile())){
+                                IOUtils.copy(in, out);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Underlying problem was that the class MappingPanel handles both table -> table and field -> field mappings, since they are higly similar. Recently some functionality was added that should only apply to tables (hiding tables from the view), but it affected the field -> field views as well. 
This was fixed by making the MappingPanel class aware of the type of mapping it was handling (between tables or between fields).
A test was added to confirm this. Since the RiaH tests take a significant amount of time, the tests were moved to the verification phase (use `mvn verify` to run them).